### PR TITLE
Acquire scheduling lock in NewChunkHolder#onFullChunkLoadChange

### DIFF
--- a/patches/server/0016-Acquire-scheduling-lock-in-NewChunkHolder-onFullChun.patch
+++ b/patches/server/0016-Acquire-scheduling-lock-in-NewChunkHolder-onFullChun.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Sat, 1 Apr 2023 00:34:29 -0700
+Subject: [PATCH] Acquire scheduling lock in
+ NewChunkHolder#onFullChunkLoadChange
+
+It modifies data that should be held by the lock: pending
+chunk status
+
+diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
+index 3b70ccd8e0b1ada943f57faf99c23b2935249cf6..12feb739a784a0108256451a37d94d041b7a5cdc 100644
+--- a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
++++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
+@@ -1203,8 +1203,12 @@ public final class NewChunkHolder {
+         }
+     }
+ 
+-    // only call on main thread, must hold ticket level and scheduling lock
++    // only call on main thread // Folia - update comment
+     private void onFullChunkLoadChange(final boolean loaded, final List<NewChunkHolder> changedFullStatus) {
++        // Folia start - chunk system fix - acquire scheduling lock
++        this.scheduler.schedulingLock.lock();
++        try {
++        // Folia end - chunk system fix - acquire scheduling lock
+         for (int dz = -NEIGHBOUR_RADIUS; dz <= NEIGHBOUR_RADIUS; ++dz) {
+             for (int dx = -NEIGHBOUR_RADIUS; dx <= NEIGHBOUR_RADIUS; ++dx) {
+                 final NewChunkHolder holder = (dx | dz) == 0 ? this : this.scheduler.chunkHolderManager.getChunkHolder(dx + this.chunkX, dz + this.chunkZ);
+@@ -1219,6 +1223,11 @@ public final class NewChunkHolder {
+                 }
+             }
+         }
++        // Folia start - chunk system fix - acquire scheduling lock
++        } finally {
++            this.scheduler.schedulingLock.unlock();
++        }
++        // Folia end - chunk system fix - acquire scheduling lock
+     }
+ 
+     private ChunkHolder.FullChunkStatus updateCurrentState(final ChunkHolder.FullChunkStatus to) {


### PR DESCRIPTION
It modifies data that should be held by the lock: pending chunk status